### PR TITLE
Adds support for Arbitrary specializations with non-default template parameters

### DIFF
--- a/src/include/arbitrary_associative_containers.h
+++ b/src/include/arbitrary_associative_containers.h
@@ -67,25 +67,31 @@ namespace testinator
   //------------------------------------------------------------------------------
   // specializations for set types
   //------------------------------------------------------------------------------
-  template <typename T>
-  struct Arbitrary<std::set<T>> : public Arbitrary_Assoc<std::set<T>> {};
+  template <typename T, typename Compare, typename Alloc>
+  struct Arbitrary<std::set<T, Compare, Alloc>> : public Arbitrary_Assoc<std::set<T, Compare, Alloc>> {};
 
-  template <typename T>
-  struct Arbitrary<std::multiset<T>> : public Arbitrary_Assoc<std::multiset<T>> {};
+  template <typename T, typename Compare, typename Alloc>
+  struct Arbitrary<std::multiset<T, Compare, Alloc>> : public Arbitrary_Assoc<std::multiset<T, Compare, Alloc>> {};
 
-  template <typename T>
-  struct Arbitrary<std::unordered_set<T>> : public Arbitrary_Assoc<std::unordered_set<T>> {};
+  template <typename T, typename Hash, typename KeyEq, typename Alloc>
+  struct Arbitrary<std::unordered_set<T, Hash, KeyEq, Alloc>> :
+      public Arbitrary_Assoc<std::unordered_set<T, Hash, KeyEq, Alloc>>
+  {};
 
   //------------------------------------------------------------------------------
   // specializations for map types
   //------------------------------------------------------------------------------
-  template <typename K, typename V>
-  struct Arbitrary<std::map<K, V>> : public Arbitrary_Assoc<std::map<K, V>> {};
+  template <typename K, typename V, typename Compare, typename Alloc>
+  struct Arbitrary<std::map<K, V, Compare, Alloc>> : public Arbitrary_Assoc<std::map<K, V, Compare, Alloc>> {};
 
-  template <typename K, typename V>
-  struct Arbitrary<std::multimap<K, V>> : public Arbitrary_Assoc<std::multimap<K, V>> {};
+  template <typename K, typename V, typename Compare, typename Alloc>
+  struct Arbitrary<std::multimap<K, V, Compare, Alloc>> :
+      public Arbitrary_Assoc<std::multimap<K, V, Compare, Alloc>>
+  {};
 
-  template <typename K, typename V>
-  struct Arbitrary<std::unordered_map<K, V>> : public Arbitrary_Assoc<std::unordered_map<K, V>> {};
+  template <typename K, typename V, typename Hash, typename KeyEq, typename Alloc>
+  struct Arbitrary<std::unordered_map<K, V, Hash, KeyEq, Alloc>> :
+      public Arbitrary_Assoc<std::unordered_map<K, V, Hash, KeyEq, Alloc>>
+  {};
 
 }

--- a/src/include/arbitrary_sequence_containers.h
+++ b/src/include/arbitrary_sequence_containers.h
@@ -60,23 +60,25 @@ namespace testinator
   //------------------------------------------------------------------------------
   // specializations for sequence containers
   //------------------------------------------------------------------------------
-  template <typename T>
-  struct Arbitrary<std::vector<T>> : public Arbitrary_RandomSequence<std::vector<T>> {};
+  template <typename T, typename Alloc>
+  struct Arbitrary<std::vector<T, Alloc>> : public Arbitrary_RandomSequence<std::vector<T, Alloc>> {};
 
-  template <typename T>
-  struct Arbitrary<std::deque<T>> : public Arbitrary_RandomSequence<std::deque<T>> {};
+  template <typename T, typename Alloc>
+  struct Arbitrary<std::deque<T, Alloc>> : public Arbitrary_RandomSequence<std::deque<T, Alloc>> {};
 
   //------------------------------------------------------------------------------
   // specialization for list
   //------------------------------------------------------------------------------
-  template <typename T>
-  struct Arbitrary<std::list<T>>
+  template <typename T, typename Alloc>
+  struct Arbitrary<std::list<T, Alloc>>
   {
+    typedef std::list<T, Alloc> output_type;
+    
     static const std::size_t N = 10;
 
-    static std::list<T> generate(std::size_t generation, unsigned long int randomSeed)
+    static output_type generate(std::size_t generation, unsigned long int randomSeed)
     {
-      std::list<T> v;
+      output_type v;
       if (generation == 0) return v;
       std::size_t n = N * ((generation / 100) + 1);
       std::generate_n(std::back_inserter(v), n,
@@ -84,26 +86,26 @@ namespace testinator
       return v;
     }
 
-    static std::list<T> generate_n(std::size_t n, unsigned long int randomSeed)
+    static output_type generate_n(std::size_t n, unsigned long int randomSeed)
     {
-      std::list<T> v;
+      output_type v;
       std::generate_n(std::back_inserter(v), n,
                       [&] () { return Arbitrary<T>::generate_n(n, randomSeed++); });
       return v;
     }
 
-    static std::vector<std::list<T>> shrink(const std::list<T>& t)
+    static std::vector<output_type> shrink(const output_type& t)
     {
-      std::vector<std::list<T>> v;
+      std::vector<output_type> v;
       if (t.empty()) return v;
       auto l = t.size() / 2;
       auto it = t.cbegin();
-      v.push_back(std::list<T>());
+      v.push_back(output_type());
       for (decltype(l) count = 0; count < l; count++, it++)
         v[0].push_back(*it);
       if (l > 0)
       {
-        v.push_back(std::list<T>());
+        v.push_back(output_type());
         copy(it, t.cend(), std::back_inserter(v[1]));
       }
       return v;
@@ -113,14 +115,16 @@ namespace testinator
   //------------------------------------------------------------------------------
   // specialization for forward_list
   //------------------------------------------------------------------------------
-  template <typename T>
-  struct Arbitrary<std::forward_list<T>>
+  template <typename T, typename Alloc>
+  struct Arbitrary<std::forward_list<T, Alloc>>
   {
+    typedef std::forward_list<T, Alloc> output_type;
+    
     static const std::size_t N = 10;
 
-    static std::forward_list<T> generate(std::size_t generation, unsigned long int randomSeed)
+    static output_type generate(std::size_t generation, unsigned long int randomSeed)
     {
-      std::forward_list<T> v;
+      output_type v;
       if (generation == 0) return v;
       std::size_t n = N * ((generation / 100) + 1);
       std::generate_n(std::front_inserter(v), n,
@@ -128,26 +132,26 @@ namespace testinator
       return v;
     }
 
-    static std::forward_list<T> generate_n(std::size_t n, unsigned long int randomSeed)
+    static output_type generate_n(std::size_t n, unsigned long int randomSeed)
     {
-      std::forward_list<T> v;
+      output_type v;
       std::generate_n(std::front_inserter(v), n,
                       [&] () { return Arbitrary<T>::generate_n(n, randomSeed++); });
       return v;
     }
 
-    static std::vector<std::forward_list<T>> shrink(const std::forward_list<T>& t)
+    static std::vector<output_type> shrink(const output_type& t)
     {
-      std::vector<std::forward_list<T>> v;
+      std::vector<output_type> v;
       if (t.empty()) return v;
       auto l = std::distance(t.cbegin(), t.cend()) / 2;
       auto it = t.cbegin();
-      v.push_back(std::forward_list<T>());
+      v.push_back(output_type());
       for (auto count = 0; count < l; count++, it++)
         v[0].push_front(*it);
       if (l > 0)
       {
-        v.push_back(std::forward_list<T>());
+        v.push_back(output_type());
         copy(it, t.cend(), std::front_inserter(v[1]));
       }
       return v;

--- a/src/include/arbitrary_string.h
+++ b/src/include/arbitrary_string.h
@@ -15,15 +15,17 @@ namespace testinator
   //------------------------------------------------------------------------------
   // specialization for string
   //------------------------------------------------------------------------------
-  template <typename T>
-  struct Arbitrary<std::basic_string<T>>
+  template <typename T, typename CharTraits, typename Alloc>
+  struct Arbitrary<std::basic_string<T, CharTraits, Alloc>>
   {
+    typedef std::basic_string<T, CharTraits, Alloc> output_type;
+    
     static const std::size_t N = 10;
 
-    static std::basic_string<T> generate(
+    static output_type generate(
         std::size_t generation, unsigned long int randomSeed)
     {
-      std::basic_string<T> s;
+      output_type s;
       if (generation == 0) return s;
       std::size_t n = N * ((generation / 100) + 1);
       s.reserve(n);
@@ -32,18 +34,18 @@ namespace testinator
       return s;
     }
 
-    static std::basic_string<T> generate_n(std::size_t n, unsigned long int randomSeed)
+    static output_type generate_n(std::size_t n, unsigned long int randomSeed)
     {
-      std::basic_string<T> s;
+      output_type s;
       s.reserve(n);
       std::generate_n(std::back_inserter(s), n,
                       [&] () { return Arbitrary<T>::generate_n(n, randomSeed++); });
       return s;
     }
 
-    static std::vector<std::basic_string<T>> shrink(const std::basic_string<T>& t)
+    static std::vector<output_type> shrink(const output_type& t)
     {
-      std::vector<std::basic_string<T>> v;
+      std::vector<output_type> v;
       if (t.empty()) return v;
       auto l = t.size() / 2;
       v.push_back(t.substr(0, l));


### PR DESCRIPTION
I wanted to use a vector with a custom allocator, so I added support for doing so with all containers.