### PR TITLE
emplace_back std::pair parameters rather than push_back

### DIFF
--- a/src/include/arbitrary_utility.h
+++ b/src/include/arbitrary_utility.h
@@ -55,14 +55,14 @@ namespace testinator
       auto first_v = Arbitrary<std::decay_t<T1>>::shrink(p.first);
       for (auto&& e : first_v)
       {
-        ret.emplace_back(std::forward<decltype(e)>(e), p.second);
+        ret.emplace_back(e, p.second);
       }
 
       // shrink the second
       auto second_v = Arbitrary<std::decay_t<T2>>::shrink(p.second);
       for (auto&& e : second_v)
       {
-        ret.emplace_back(p.first, std::forward<decltype(e)>(e));
+        ret.emplace_back(p.first, e);
       }
 
       return ret;

--- a/src/include/arbitrary_utility.h
+++ b/src/include/arbitrary_utility.h
@@ -55,14 +55,14 @@ namespace testinator
       auto first_v = Arbitrary<std::decay_t<T1>>::shrink(p.first);
       for (auto&& e : first_v)
       {
-        ret.push_back(std::make_pair(e, p.second));
+        ret.emplace_back(std::forward<decltype(e)>(e), p.second);
       }
 
       // shrink the second
       auto second_v = Arbitrary<std::decay_t<T2>>::shrink(p.second);
       for (auto&& e : second_v)
       {
-        ret.push_back(std::make_pair(p.first, e));
+        ret.emplace_back(p.first, std::forward<decltype(e)>(e));
       }
 
       return ret;


### PR DESCRIPTION
Instead of calling push_back with a temporary std::pair, use emplace_back with the arguments directly. This avoids an unnecessary std::pair object being creating along with the accompanying move.