### PR TITLE
refactor: update minimum cmake version and refactor code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .sconsign.dblite
-build/
+*build*/
 export/
 TAGS
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 2.8)
-project (testinator)
+cmake_minimum_required (VERSION 3.0)
+project (testinator LANGUAGES CXX)
 
 # Includes for this project
 include_directories ("${PROJECT_SOURCE_DIR}/src/include")
@@ -64,7 +64,7 @@ if("x${CMAKE_CXX_COMPILER_ID}" MATCHES "x.*Clang")
   if(ASAN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,undefined,integer -fno-omit-frame-pointer -fno-sanitize=unsigned-integer-overflow")
   endif()
-elseif(CMAKE_COMPILER_IS_GNUCXX)
+elseif("x${CMAKE_CXX_COMPILER_ID}" MATCHES "xGNU")
   if(NOT GCOV)
     find_program(GCOV gcov)
   endif()

--- a/src/include/arbitrary_arithmetic.h
+++ b/src/include/arbitrary_arithmetic.h
@@ -199,7 +199,7 @@ namespace testinator
 
     static std::vector<bool> shrink(const bool&)
     {
-      return std::vector<bool>();
+      return {};
     }
   };
 
@@ -224,7 +224,7 @@ namespace testinator
 
     static std::vector<char> shrink(const char&)
     {
-      return std::vector<char>();
+      return {};
     }
   };
 

--- a/src/include/branch.h
+++ b/src/include/branch.h
@@ -16,10 +16,10 @@ namespace testinator
   class AtScopeExit
   {
   public:
-    AtScopeExit(const F& f) : m_f(f) {}
-    AtScopeExit(F&& f) : m_f(std::move(f)) {}
+    explicit AtScopeExit(const F& f) : m_f(f) {}
+    explicit AtScopeExit(F&& f) : m_f(std::move(f)) {}
     ~AtScopeExit() { m_f(); }
-    operator bool() const { return true; }
+    explicit operator bool() const { return true; }
   private:
     F m_f;
   };

--- a/src/include/complexity.h
+++ b/src/include/complexity.h
@@ -44,9 +44,11 @@ namespace testinator
 
       // discard the outer values, take the means of each set
       double timeN = static_cast<double>(
-          std::accumulate(&countsN[1], &countsN[size-2], int64_t{0})) / (size - 2);
+          std::accumulate(&countsN[1], &countsN[size-2], int64_t{0})) /
+                     static_cast<double>(size - 2);
       double timeMultN = static_cast<double>(
-          std::accumulate(&countsMultN[1], &countsMultN[size-2], int64_t{0})) / (size - 2);
+          std::accumulate(&countsMultN[1], &countsMultN[size-2], int64_t{0})) /
+                         static_cast<double>(size - 2);
 
       // the actual ratio of times
       double actualRatio = timeMultN / timeN;
@@ -106,7 +108,7 @@ namespace testinator
     }
 
     template <typename F>
-    ComplexityProperty(const F& f)
+    explicit ComplexityProperty(const F& f)
       : m_internal(std::make_unique<Internal<F>>(f))
     {
     }
@@ -119,7 +121,7 @@ namespace testinator
   private:
     struct InternalBase
     {
-      virtual ~InternalBase() {}
+      virtual ~InternalBase() = default;
       virtual int check(std::size_t N) = 0;
     };
 
@@ -128,9 +130,9 @@ namespace testinator
     {
       using argTuple = typename function_traits<U>::argTuple;
 
-      Internal(const U& u) : m_u(u) {}
+      explicit Internal(const U& u) : m_u(u) {}
 
-      virtual int check(std::size_t N) override
+      int check(std::size_t N) override
       {
         // Get the timings for N and N * MULTIPLIER, NUM_ITER samples each
         int64_t countsN[NUM_ITER];

--- a/src/include/property.h
+++ b/src/include/property.h
@@ -26,7 +26,7 @@ namespace testinator
   {
   public:
     template <typename F>
-    Property(const F& f)
+    explicit Property(const F& f)
       : m_internal(std::make_unique<Internal<F>>(f))
     {
     }

--- a/src/include/test.h
+++ b/src/include/test.h
@@ -34,7 +34,7 @@ namespace testinator
   {
     std::string m_suiteName;
     std::string m_testName;
-    bool m_success;
+    bool m_success{};
   };
 
   using Results = std::vector<Result>;
@@ -47,7 +47,7 @@ namespace testinator
   public:
     Test(TestRegistry& reg, const std::string& name,
          const std::string& suiteName = std::string());
-    Test(const std::string& name, const std::string& suiteName = std::string());
+    explicit Test(const std::string& name, const std::string& suiteName = std::string());
     virtual ~Test();
 
     virtual bool Setup(const RunParams&) { return true; }
@@ -70,7 +70,7 @@ namespace testinator
     bool m_skipped = false;
     const std::string m_name;
     TestRegistry& m_registry;
-    const Outputter* m_op;
+    const Outputter* m_op{};
   };
 }
 

--- a/src/include/test_registry.h
+++ b/src/include/test_registry.h
@@ -48,14 +48,10 @@ namespace testinator
 
       const std::string& suiteName = m_suiteNames[test];
       auto range = m_testsBySuite.equal_range(suiteName);
-      for (auto& i = range.first; i != range.second; ++i)
-      {
-        if (i->second == test)
-        {
-          m_testsBySuite.erase(i);
-          break;
-        }
-      }
+      auto pos = std::find_if(range.first, range.second, [&test](auto& suite)
+                              {return suite.second == test;});
+      if(pos != range.second) m_testsBySuite.erase(pos);
+
       m_suiteNames.erase(test);
     }
 
@@ -95,7 +91,7 @@ namespace testinator
     {
       auto i = m_tests.find(testName);
       if (i == m_tests.end())
-        return std::vector<Result>();
+        return {};
 
       TestMap localMap;
       localMap.insert({testName, i->second});
@@ -158,7 +154,7 @@ namespace testinator
       return rs;
     }
 
-    Result RunTest(Test* test,
+    static Result RunTest(Test* test,
                    const RunParams& params,
                    const Outputter* outputter)
     {

--- a/src/include/timed_test.h
+++ b/src/include/timed_test.h
@@ -18,7 +18,7 @@ namespace testinator
   {
   public:
     template <typename F>
-    TimedTest(const F& f)
+    explicit TimedTest(const F& f)
       : m_internal(std::make_unique<Internal<F>>(f))
     {
     }
@@ -31,17 +31,17 @@ namespace testinator
   private:
     struct InternalBase
     {
-      virtual ~InternalBase() {}
+      virtual ~InternalBase() = default;
       virtual void check(std::size_t N, const Outputter*) = 0;
     };
 
     template <typename U>
     struct Internal : public InternalBase
     {
-      Internal(const U& u) : m_u(u) {}
+      explicit Internal(const U& u) : m_u(u) {}
 
-      virtual void check(std::size_t N,
-                         const Outputter* op)
+      void check(std::size_t N,
+                         const Outputter* op) override
       {
         auto t1 = std::chrono::high_resolution_clock::now();
         for (std::size_t i = 0; i < N; ++i)

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -14,16 +14,16 @@ using namespace std;
 //------------------------------------------------------------------------------
 namespace
 {
-  static const char* s_suiteName = "Test";
+  const char* s_suiteName = "Test";
 }
 
 //------------------------------------------------------------------------------
 class TestCallTest : public testinator::Test
 {
 public:
-  TestCallTest(const string& name) : testinator::Test(name, s_suiteName) {}
+  explicit TestCallTest(const string& name) : testinator::Test(name, s_suiteName) {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -40,18 +40,18 @@ public:
 class TestSetupFirst : public testinator::Test
 {
 public:
-  TestSetupFirst(const string& name)
+  explicit TestSetupFirst(const string& name)
     : testinator::Test(name, s_suiteName)
     , m_setupCalled(false)
   {}
 
-  virtual bool Setup(const testinator::RunParams&)
+  bool Setup(const testinator::RunParams&) override
   {
     m_setupCalled = true;
     return true;
   }
 
-  virtual bool Run()
+  bool Run() override
   {
     return m_setupCalled;
   }
@@ -69,7 +69,7 @@ public:
     , m_runCalled(false)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     m_runCalled = true;
     return true;
@@ -82,11 +82,11 @@ public:
 class TestRunMultiple : public testinator::Test
 {
 public:
-  TestRunMultiple(const string& name)
+  explicit TestRunMultiple(const std::string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -110,7 +110,7 @@ public:
     , m_fail(fail)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     return !m_fail;
   }
@@ -122,11 +122,11 @@ public:
 class TestReportResults : public testinator::Test
 {
 public:
-  TestReportResults(const string& name)
+  explicit TestReportResults(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -149,11 +149,11 @@ public:
 class TestRunSuite : public testinator::Test
 {
 public:
-  TestRunSuite(const string& name)
+  explicit TestRunSuite(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -178,7 +178,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     bool fail = true;
     EXPECT(!fail == fail);
@@ -190,11 +190,11 @@ public:
 class TestExpectMacro : public testinator::Test
 {
 public:
-  TestExpectMacro(const string& name)
+  explicit TestExpectMacro(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -214,7 +214,7 @@ public:
 //------------------------------------------------------------------------------
 struct CountEvals
 {
-  bool inc() { ++s_evals; return true; }
+  static bool inc() { ++s_evals; return true; }
   static int s_evals;
 };
 int CountEvals::s_evals = 0;
@@ -226,7 +226,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     CountEvals c;
     EXPECT(c.inc() == c.inc());
@@ -239,11 +239,11 @@ public:
 class TestExpectEvalsOnce : public testinator::Test
 {
 public:
-  TestExpectEvalsOnce(const string& name)
+  explicit TestExpectEvalsOnce(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -268,7 +268,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     DIAGNOSTIC("Hello world " << 42 << endl << 42);
     DIAGNOSTIC("Hello world " << std::hex << 42);
@@ -280,11 +280,11 @@ public:
 class TestDiagnostic : public testinator::Test
 {
 public:
-  TestDiagnostic(const string& name)
+  explicit TestDiagnostic(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -310,7 +310,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     m_runCalled = true;
     ABORT("Hello world " << 42);
@@ -324,11 +324,11 @@ public:
 class TestAbort : public testinator::Test
 {
 public:
-  TestAbort(const string& name)
+  explicit TestAbort(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -355,7 +355,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     SKIP("Hello world " << 42);
     return false;
@@ -366,11 +366,11 @@ public:
 class TestSkip : public testinator::Test
 {
 public:
-  TestSkip(const string& name)
+  explicit TestSkip(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -392,7 +392,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     DIAGNOSTIC("no branch");
 
@@ -414,11 +414,11 @@ public:
 class TestBranch : public testinator::Test
 {
 public:
-  TestBranch(const string& name)
+  explicit TestBranch(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -439,11 +439,11 @@ public:
 class TestBranchInternal2 : public testinator::Test
 {
 public:
-  TestBranchInternal2(const string& name)
+  explicit TestBranchInternal2(const string& name)
     : testinator::Test(name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     BRANCH()
     {
@@ -458,11 +458,11 @@ public:
 class TestBranchNoName : public testinator::Test
 {
 public:
-  TestBranchNoName(const string& name)
+  explicit TestBranchNoName(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     ostringstream oss;
     std::unique_ptr<testinator::Outputter> op =
@@ -480,7 +480,7 @@ public:
 class TestTAPSkip : public testinator::Test
 {
 public:
-  TestTAPSkip(const string& name)
+  explicit TestTAPSkip(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
@@ -504,11 +504,11 @@ public:
 class TestTAPDiagnostic : public testinator::Test
 {
 public:
-  TestTAPDiagnostic(const string& name)
+  explicit TestTAPDiagnostic(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -528,11 +528,11 @@ public:
 class TestTAPAbort : public testinator::Test
 {
 public:
-  TestTAPAbort(const string& name)
+  explicit TestTAPAbort(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -560,7 +560,7 @@ public:
     : testinator::Test(r, name, suite)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     return true;
   }
@@ -570,11 +570,11 @@ public:
 class TestRuns : public testinator::Test
 {
 public:
-  TestRuns(const string& name)
+  explicit TestRuns(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     {
       testinator::TestRegistry r;
@@ -605,11 +605,11 @@ public:
 class TestNoSuchTest : public testinator::Test
 {
 public:
-  TestNoSuchTest(const string& name)
+  explicit TestNoSuchTest(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     testinator::Results rs = r.RunTest("A");
@@ -625,7 +625,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Setup(const testinator::RunParams&)
+  bool Setup(const testinator::RunParams&) override
   {
     return false;
   }
@@ -635,11 +635,11 @@ public:
 class TestSkipOnSetupFail : public testinator::Test
 {
 public:
-  TestSkipOnSetupFail(const string& name)
+  explicit TestSkipOnSetupFail(const string& name)
     : testinator::Test(name, s_suiteName)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     testinator::TestRegistry r;
     ostringstream oss;
@@ -675,7 +675,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     EXPECT(1+2 > 1+3 < 0);
     EXPECT(false);
@@ -706,7 +706,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     vector<int> v = {1,2,3};
     DIAGNOSTIC(testinator::prettyprint(v));
@@ -741,7 +741,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     DIAGNOSTIC(testinator::ComplexityProperty::Order(testinator::ORDER_1));
     return true;
@@ -771,7 +771,7 @@ public:
     : testinator::Test(r, name)
   {}
 
-  virtual bool Run()
+  bool Run() override
   {
     DIAGNOSTIC("Foo");
     SKIP("Foo");

--- a/src/test/property.cpp
+++ b/src/test/property.cpp
@@ -57,7 +57,7 @@ public:
     : testinator::PropertyTest(r, name, suite)
   {}
 
-  virtual bool Run() override
+  bool Run() override
   {
     testinator::Property p(*this);
     return p.check(m_numChecks, m_op);
@@ -131,7 +131,7 @@ public:
     : testinator::PropertyTest(r, name, suite)
   {}
 
-  virtual bool Run() override
+  bool Run() override
   {
     testinator::Property p(*this);
     return p.check(m_numChecks, m_op);
@@ -169,7 +169,7 @@ public:
     : testinator::PropertyTest(r, name, suite)
   {}
 
-  virtual bool Run() override
+  bool Run() override
   {
     testinator::Property p(*this);
     return p.check(m_numChecks, m_op);
@@ -213,7 +213,7 @@ public:
     : testinator::PropertyTest(r, name, suite)
   {}
 
-  virtual bool Run() override
+  bool Run() override
   {
     testinator::Property p(*this);
     return p.check(m_numChecks, m_op);
@@ -318,10 +318,10 @@ namespace testinator
   struct Arbitrary<MyBoundedType>
   {
     static MyBoundedType generate(std::size_t generation, unsigned long int /*randomSeed*/)
-    { return MyBoundedType(generation % MyBoundedType::MAX_VAL); }
+    { return {generation % MyBoundedType::MAX_VAL}; }
 
     static vector<MyBoundedType> shrink(const MyBoundedType&)
-    { return vector<MyBoundedType>(); }
+    { return {}; }
   };
 }
 


### PR DESCRIPTION
- Update the minimum required cmake version to avoid using a deprecated default
- Refactor portions of the code for improved readability and maintainability